### PR TITLE
Replace Cyrillic 'C' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ func main() {
 	if err != nil {
 		return
 	}
-	fmt.Println(resp.Сhoices[0].Text)
+	fmt.Println(resp.Choices[0].Text)
 
 	searchReq := gogpt.SearchRequest{
 		Documents: []string{"White House", "hospital", "school"},


### PR DESCRIPTION
Sorry for not including this in the previous PR.. the example in the docs includes the 'C' as well, so I don't think it would compile.