### PR TITLE
api.go: add constructor variant for organizations

### DIFF
--- a/api.go
+++ b/api.go
@@ -9,28 +9,47 @@ import (
 
 const apiURLv1 = "https://api.openai.com/v1"
 
+func newTransport() *http.Client {
+	return &http.Client{
+		Timeout: time.Minute,
+	}
+}
+
 // Client is OpenAI GPT-3 API client
 type Client struct {
 	BaseURL    string
-	authToken  string
 	HTTPClient *http.Client
+	authToken  string
+	idOrg      string
 }
 
 // NewClient creates new OpenAI API client
 func NewClient(authToken string) *Client {
 	return &Client{
-		BaseURL:   apiURLv1,
-		authToken: authToken,
-		HTTPClient: &http.Client{
-			Timeout: time.Minute,
-		},
+		BaseURL:    apiURLv1,
+		HTTPClient: newTransport(),
+		authToken:  authToken,
+		idOrg:      "",
+	}
+}
+
+// NewOrgClient creates new OpenAI API client for specified Organization ID
+func NewOrgClient(authToken, org string) *Client {
+	return &Client{
+		BaseURL:    apiURLv1,
+		HTTPClient: newTransport(),
+		authToken:  authToken,
+		idOrg:      org,
 	}
 }
 
 func (c *Client) sendRequest(req *http.Request, v interface{}) error {
-	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	req.Header.Set("Accept", "application/json; charset=utf-8")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.authToken))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	if len(c.idOrg) > 0 {
+		req.Header.Set("OpenAI-Organization", c.idOrg)
+	}
 
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
To set the `OpenAI-Organization` header, if appropriate.

https://beta.openai.com/docs/api-reference/authentication