### PR TITLE
Add CreateCompletionWithFineTunedModel function

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -73,3 +73,21 @@ func (c *Client) CreateCompletion(ctx context.Context, engineID string, request 
 	err = c.sendRequest(req, &response)
 	return
 }
+
+func (c *Client) CreateCompletionWithFineTunedModel(ctx context.Context, request CompletionRequest) (response CompletionResponse, err error) {
+	var reqBytes []byte
+	reqBytes, err = json.Marshal(request)
+	if err != nil {
+		return
+	}
+
+	urlSuffix := "/completions"
+	req, err := http.NewRequest("POST", c.fullURL(urlSuffix), bytes.NewBuffer(reqBytes))
+	if err != nil {
+		return
+	}
+
+	req = req.WithContext(ctx)
+	err = c.sendRequest(req, &response)
+	return
+}

--- a/completion.go
+++ b/completion.go
@@ -74,6 +74,9 @@ func (c *Client) CreateCompletion(ctx context.Context, engineID string, request 
 	return
 }
 
+// CreateCompletionWithFineTunedModel - API call to create a completion with a fine tuned model
+// See https://beta.openai.com/docs/guides/fine-tuning/use-a-fine-tuned-model
+// In this case, the model is specified in the CompletionRequest object.
 func (c *Client) CreateCompletionWithFineTunedModel(ctx context.Context, request CompletionRequest) (response CompletionResponse, err error) {
 	var reqBytes []byte
 	reqBytes, err = json.Marshal(request)


### PR DESCRIPTION
OpenAI recently added the ability to use a fine-tuned model to generate completions with GPT-3.

This PR adds a function to implement this feature, which uses a different endpoint than CreateCompletion.

See here for the format: https://beta.openai.com/docs/guides/fine-tuning/use-a-fine-tuned-model

Lmk if any additional comments etc would be useful here.