### PR TITLE
Support both old & new structs for moderation.go

### DIFF
--- a/moderation.go
+++ b/moderation.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 )
 
+// ---- These are the old structs and will likely be deprecated soon.
 // ModerationRequest represents a request structure for moderation API
 type ModerationRequest struct {
 	Input string  `json:"input,omitempty"`
@@ -17,18 +18,18 @@ type ModerationRequest struct {
 type Result struct {
 	Categories     ResultCategories     `json:"categories"`
 	CategoryScores ResultCategoryScores `json:"category_scores"`
-	Flagged        bool                 `json:"flagged"`
+	Flagged        int                  `json:"flagged"`
 }
 
 // ResultCategories represents Categories of Result
 type ResultCategories struct {
-	Hate            bool `json:"hate"`
-	HateThreatening bool `json:"hate/threatening"`
-	SelfHarm        bool `json:"self-harm"`
-	Sexual          bool `json:"sexual"`
-	SexualMinors    bool `json:"sexual/minors"`
-	Violence        bool `json:"violence"`
-	ViolenceGraphic bool `json:"violence/graphic"`
+	Hate            int `json:"hate"`
+	HateThreatening int `json:"hate/threatening"`
+	SelfHarm        int `json:"self-harm"`
+	Sexual          int `json:"sexual"`
+	SexualMinors    int `json:"sexual/minors"`
+	Violence        int `json:"violence"`
+	ViolenceGraphic int `json:"violence/graphic"`
 }
 
 // ResultCategoryScores represents CategoryScores of Result
@@ -49,9 +50,71 @@ type ModerationResponse struct {
 	Results []Result `json:"results"`
 }
 
-// Moderations — perform a moderation api call over a string.
+// ModerationOld — perform a moderation api call over a string.
 // Input can be an array or slice but a string will reduce the complexity.
-func (c *Client) Moderations(ctx context.Context, request ModerationRequest) (response ModerationResponse, err error) {
+func (c *Client) ModerationsOld(ctx context.Context, request ModerationRequest) (response ModerationResponse, err error) {
+	var reqBytes []byte
+	reqBytes, err = json.Marshal(request)
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequest("POST", c.fullURL("/moderations"), bytes.NewBuffer(reqBytes))
+	if err != nil {
+		return
+	}
+
+	req = req.WithContext(ctx)
+	err = c.sendRequest(req, &response)
+	return
+}
+
+// ---- These are the new structs and will likely be used in starting Friday, August 5th 2022.
+// ModerationRequestNew represents a request structure for moderation API
+type ModerationRequestNew struct {
+	Input string  `json:"input,omitempty"`
+	Model *string `json:"model,omitempty"`
+}
+
+// ResultNew represents one of possible moderation NewResults
+type ResultNew struct {
+	Categories     ResultNewCategories     `json:"categories"`
+	CategoryScores ResultNewCategoryScores `json:"category_scores"`
+	Flagged        bool                    `json:"flagged"`
+}
+
+// ResultNewCategories represents Categories of ResultNew
+type ResultNewCategories struct {
+	Hate            bool `json:"hate"`
+	HateThreatening bool `json:"hate/threatening"`
+	SelfHarm        bool `json:"self-harm"`
+	Sexual          bool `json:"sexual"`
+	SexualMinors    bool `json:"sexual/minors"`
+	Violence        bool `json:"violence"`
+	ViolenceGraphic bool `json:"violence/graphic"`
+}
+
+// ResultNewCategoryScores represents CategoryScores of ResultNew
+type ResultNewCategoryScores struct {
+	Hate            float32 `json:"hate"`
+	HateThreatening float32 `json:"hate/threatening"`
+	SelfHarm        float32 `json:"self-harm"`
+	Sexual          float32 `json:"sexual"`
+	SexualMinors    float32 `json:"sexual/minors"`
+	Violence        float32 `json:"violence"`
+	ViolenceGraphic float32 `json:"violence/graphic"`
+}
+
+// ModerationResponseNew represents a response structure for moderation API
+type ModerationResponseNew struct {
+	ID         string      `json:"id"`
+	Model      string      `json:"model"`
+	NewResults []ResultNew `json:"NewResults"`
+}
+
+// ModerationsNew — perform a moderation api call over a string.
+// Input can be an array or slice but a string will reduce the complexity.
+func (c *Client) ModerationsNew(ctx context.Context, request ModerationRequestNew) (response ModerationResponseNew, err error) {
 	var reqBytes []byte
 	reqBytes, err = json.Marshal(request)
 	if err != nil {


### PR DESCRIPTION
This should fix the error:
`json: cannot unmarshal number into Go struct field ResultCategories.results.categories.hate of type bool`

Looking at this [comment](https://github.com/sashabaranov/go-gpt3/issues/27#issuecomment-1202149781), it seems that OpenAI still haven't applied the new changes, and the previous pull request will cause the above json error.

I decided to include both the current moderation struct & the new struct that will likely be used in the near future.