### PR TITLE
Add new text-davinci-003 model to constants

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -12,6 +12,7 @@ import (
 // GPT3 Models are designed for text-based tasks. For code-specific
 // tasks, please refer to the Codex series of models.
 const (
+	GPT3TextDavinci003      = "text-davinci-003"
 	GPT3TextDavinci002      = "text-davinci-002"
 	GPT3TextCurie001        = "text-curie-001"
 	GPT3TextBabbage001      = "text-babbage-001"


### PR DESCRIPTION
Open AI Announced their new completion model `text-davinci-003` This is not available for any other endpoints at the moment.

https://beta.openai.com/docs/models/overview