### PR TITLE
Add Suffix to CompletionRequest for insert mode

### DIFF
--- a/completion.go
+++ b/completion.go
@@ -39,6 +39,7 @@ const (
 type CompletionRequest struct {
 	Model            string         `json:"model"`
 	Prompt           string         `json:"prompt,omitempty"`
+	Suffix           string         `json:"suffix,omitempty"`
 	MaxTokens        int            `json:"max_tokens,omitempty"`
 	Temperature      float32        `json:"temperature,omitempty"`
 	TopP             float32        `json:"top_p,omitempty"`


### PR DESCRIPTION
Add "Suffix" to "CompletionRequest" to support the new insert mode.

Insert mode info: https://openai.com/blog/gpt-3-edit-insert/
New Completion Request API Reference: https://beta.openai.com/docs/api-reference/completions/create#completions/create-prompt