### PR TITLE
Improve error reporting

### DIFF
--- a/api.go
+++ b/api.go
@@ -66,7 +66,11 @@ func (c *Client) sendRequest(req *http.Request, v interface{}) error {
 		var errRes ErrorResponse
 		err = json.NewDecoder(res.Body).Decode(&errRes)
 		if err != nil || errRes.Error == nil {
-			return fmt.Errorf("error, status code: %d", res.StatusCode)
+			reqErr := RequestError {
+				StatusCode: res.StatusCode,
+				Err: err,
+			}
+			return fmt.Errorf("error, %w", &reqErr)
 		}
 		errRes.Error.StatusCode = res.StatusCode
 		return fmt.Errorf("error, status code: %d, message: %w", res.StatusCode, errRes.Error)

--- a/api.go
+++ b/api.go
@@ -68,7 +68,8 @@ func (c *Client) sendRequest(req *http.Request, v interface{}) error {
 		if err != nil || errRes.Error == nil {
 			return fmt.Errorf("error, status code: %d", res.StatusCode)
 		}
-		return fmt.Errorf("error, status code: %d, message: %s", res.StatusCode, errRes.Error.Message)
+		errRes.Error.StatusCode = res.StatusCode
+		return fmt.Errorf("error, status code: %d, message: %w", res.StatusCode, errRes.Error)
 	}
 
 	if v != nil {

--- a/api_test.go
+++ b/api_test.go
@@ -81,6 +81,33 @@ func TestAPI(t *testing.T) {
 	}
 }
 
+func TestAPIError(t *testing.T) {
+	apiToken := os.Getenv("OPENAI_TOKEN")
+	if apiToken == "" {
+		t.Skip("Skipping testing against production OpenAI API. Set OPENAI_TOKEN environment variable to enable it.")
+	}
+
+	var err error
+	c := NewClient(apiToken + "_invalid")
+	ctx := context.Background()
+	_, err = c.ListEngines(ctx)
+	if err == nil {
+		t.Fatal("ListEngines did not fail with invalid token")
+	}
+
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("Request error is not an APIError: %+v", err)
+	}
+
+	if apiErr.StatusCode != 401 {
+		t.Fatalf("Unexpected API error status code: %d", apiErr.StatusCode)
+	}
+	if *apiErr.Code != "invalid_api_key" {
+		t.Fatalf("Unexpected API error code: %s", *apiErr.Code)
+	}
+}
+
 // numTokens Returns the number of GPT-3 encoded tokens in the given text.
 // This function approximates based on the rule of thumb stated by OpenAI:
 // https://beta.openai.com/tokenizer

--- a/api_test.go
+++ b/api_test.go
@@ -92,12 +92,12 @@ func TestAPIError(t *testing.T) {
 	ctx := context.Background()
 	_, err = c.ListEngines(ctx)
 	if err == nil {
-		t.Fatal("ListEngines did not fail with invalid token")
+		t.Fatal("ListEngines did not fail")
 	}
 
 	var apiErr *APIError
 	if !errors.As(err, &apiErr) {
-		t.Fatalf("Request error is not an APIError: %+v", err)
+		t.Fatalf("Error is not an APIError: %+v", err)
 	}
 
 	if apiErr.StatusCode != 401 {
@@ -105,6 +105,26 @@ func TestAPIError(t *testing.T) {
 	}
 	if *apiErr.Code != "invalid_api_key" {
 		t.Fatalf("Unexpected API error code: %s", *apiErr.Code)
+	}
+}
+
+func TestRequestError(t *testing.T) {
+	var err error
+	c := NewClient("dummy")
+	c.BaseURL = "https://httpbin.org/status/418?"
+	ctx := context.Background()
+	_, err = c.ListEngines(ctx)
+	if err == nil {
+		t.Fatal("ListEngines request did not fail")
+	}
+
+	var reqErr *RequestError
+	if !errors.As(err, &reqErr) {
+		t.Fatalf("Error is not a RequestError: %+v", err)
+	}
+
+	if reqErr.StatusCode != 418 {
+		t.Fatalf("Unexpected request error status code: %d", reqErr.StatusCode)
 	}
 }
 

--- a/error.go
+++ b/error.go
@@ -1,5 +1,8 @@
 package gogpt
 
+import "fmt"
+
+// APIError provides error information returned by the OpenAI API.
 type APIError struct {
 	Code       *string `json:"code,omitempty"`
 	Message    string  `json:"message"`
@@ -8,10 +11,27 @@ type APIError struct {
 	StatusCode int     `json:"-"`
 }
 
+// RequestError provides informations about generic request errors.
+type RequestError struct {
+	StatusCode int
+	Err        error
+}
+
 type ErrorResponse struct {
 	Error *APIError `json:"error,omitempty"`
 }
 
-func (er *APIError) Error() string {
-	return er.Message
+func (e *APIError) Error() string {
+	return e.Message
+}
+
+func (e *RequestError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return fmt.Sprintf("status code %d", e.StatusCode)
+}
+
+func (e *RequestError) Unwrap() error {
+	return e.Err
 }

--- a/error.go
+++ b/error.go
@@ -1,10 +1,17 @@
 package gogpt
 
+type APIError struct {
+	Code       *string `json:"code,omitempty"`
+	Message    string  `json:"message"`
+	Param      *string `json:"param,omitempty"`
+	Type       string  `json:"type"`
+	StatusCode int     `json:"-"`
+}
+
 type ErrorResponse struct {
-	Error *struct {
-		Code    *int    `json:"code,omitempty"`
-		Message string  `json:"message"`
-		Param   *string `json:"param,omitempty"`
-		Type    string  `json:"type"`
-	} `json:"error,omitempty"`
+	Error *APIError `json:"error,omitempty"`
+}
+
+func (er *APIError) Error() string {
+	return er.Message
 }


### PR DESCRIPTION
The errors returned by `sendRequest` did not allow for easy error inspection. This PR aims to improve this.

To be able to test what type of error was returned by the server, an `APIError` struct is introduced which is basically the previous `ErrorResponse.Error` struct, but with three changes:

* The `Code` field's type has been fixed, it's a `string`.
* An additional field `StatusCode int` field was added to transport the HTTP status code as well.
* Implements the `Error` interface.

There's also a new `RequestError` for errors which do not provide an API error object.

The errors returned by `sendRequest` now make use of error wrapping via `%w`. This way the returned error strings retain their previous format but `errors.Is` and `errors.As` now work to get access to the additional error information.