### PR TITLE
Configurable Transport

### DIFF
--- a/api.go
+++ b/api.go
@@ -30,6 +30,16 @@ func NewClient(authToken string) *Client {
 	}
 }
 
+// NewClientWithTransport creates new OpenAI API client with the provided http.Client.
+func NewClientWithTransport(authToken string, transport *http.Client) *Client {
+	return &Client{
+		BaseURL:    apiURLv1,
+		HTTPClient: transport,
+		authToken:  authToken,
+		idOrg:      "",
+	}
+}
+
 // NewOrgClient creates new OpenAI API client for specified Organization ID.
 func NewOrgClient(authToken, org string) *Client {
 	return &Client{
@@ -38,6 +48,22 @@ func NewOrgClient(authToken, org string) *Client {
 		authToken:  authToken,
 		idOrg:      org,
 	}
+}
+
+// NewOrgClient creates new OpenAI API client for specified Organization ID with the provided http.Client.
+func NewOrgClientWithTransport(authToken, org string, transport *http.Client) *Client {
+	return &Client{
+		BaseURL:    apiURLv1,
+		HTTPClient: transport,
+		authToken:  authToken,
+		idOrg:      org,
+	}
+}
+
+// WithTransport returns the OpenAI API client configured to use the provided http.Client.
+func (c *Client) WithTransport(transport *http.Client) *Client {
+	c.HTTPClient = transport
+	return c
 }
 
 func (c *Client) sendRequest(req *http.Request, v interface{}) error {

--- a/api.go
+++ b/api.go
@@ -50,7 +50,7 @@ func NewOrgClient(authToken, org string) *Client {
 	}
 }
 
-// NewOrgClient creates new OpenAI API client for specified Organization ID with the provided http.Client.
+// NewOrgClientWithTransport creates new OpenAI API client for specified Organization ID with the provided http.Client.
 func NewOrgClientWithTransport(authToken, org string, transport *http.Client) *Client {
 	return &Client{
 		BaseURL:    apiURLv1,

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/sashabaranov/go-gpt3
+module github.com/amplify-security/go-gpt3
 
 go 1.17

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
-module github.com/amplify-security/go-gpt3
+module github.com/sashabaranov/go-gpt3
 
 go 1.17
-
-replace github.com/sashabaranov/go-gpt3 => github.com/amplify-security/go-gpt3 configurable-transport

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/amplify-security/go-gpt3
 
 go 1.17
+
+replace github.com/sashabaranov/go-gpt3 => github.com/amplify-security/go-gpt3 configurable-transport


### PR DESCRIPTION
Non-breaking changes which allow for a configurable "Transport" (language which was already used in the project, really a `*http.Client`).

This allows for setting a custom `RoundTripper` or using `github.com/hashicorp/go-retryablehttp`:

```go
transport := retryablehttp.NewClient().StandardClient()
c := gogpt.NewClientWithTransport(openAIAPIKey, transport)
```

With the recent stability issues and load of the OpenAI API this is necessary to use the module in a production environment.