### PR TITLE
Fix endless loop while network error

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 )
 
@@ -27,9 +26,7 @@ func (stream *CompletionStream) Recv() (response CompletionResponse, err error) 
 waitForData:
 	line, err := stream.reader.ReadBytes('\n')
 	if err != nil {
-		if errors.Is(err, io.EOF) {
-			return
-		}
+		return
 	}
 
 	var headerData = []byte("data: ")


### PR DESCRIPTION
An endless loop occurs if ReadBytes() returns non-IO error, such as network interrupt.

```go
waitForData:
	line, err := stream.reader.ReadBytes('\n')
	if err != nil {
		if errors.Is(err, io.EOF) {
			return
		}
	}

	var headerData = []byte("data: ")
	line = bytes.TrimSpace(line)
	if !bytes.HasPrefix(line, headerData) {
		emptyMessagesCount++
		if emptyMessagesCount > emptyMessagesLimit {
			err = ErrTooManyEmptyStreamMessages
			return
		}

		goto waitForData
	}
```
 
![image](https://user-images.githubusercontent.com/7357939/219850485-a51c5c70-0541-4af8-96a4-59b2180dd6a8.png)
