### PR TITLE
Better configuration

### DIFF
--- a/api.go
+++ b/api.go
@@ -6,69 +6,34 @@ import (
 	"net/http"
 )
 
-const apiURLv1 = "https://api.openai.com/v1"
-
-func newTransport() *http.Client {
-	return &http.Client{}
-}
-
 // Client is OpenAI GPT-3 API client.
 type Client struct {
-	BaseURL    string
-	HTTPClient *http.Client
-	authToken  string
-	idOrg      string
+	config ClientConfig
 }
 
 // NewClient creates new OpenAI API client.
 func NewClient(authToken string) *Client {
-	return &Client{
-		BaseURL:    apiURLv1,
-		HTTPClient: newTransport(),
-		authToken:  authToken,
-		idOrg:      "",
-	}
+	config := DefaultConfig(authToken)
+	return &Client{config}
 }
 
-// NewClientWithTransport creates new OpenAI API client with the provided http.Client.
-func NewClientWithTransport(authToken string, transport *http.Client) *Client {
-	return &Client{
-		BaseURL:    apiURLv1,
-		HTTPClient: transport,
-		authToken:  authToken,
-		idOrg:      "",
-	}
+// NewClientWithConfig creates new OpenAI API client for specified config.
+func NewClientWithConfig(config ClientConfig) *Client {
+	return &Client{config}
 }
 
 // NewOrgClient creates new OpenAI API client for specified Organization ID.
+//
+// Deprecated: Please use NewClientWithConfig.
 func NewOrgClient(authToken, org string) *Client {
-	return &Client{
-		BaseURL:    apiURLv1,
-		HTTPClient: newTransport(),
-		authToken:  authToken,
-		idOrg:      org,
-	}
-}
-
-// NewOrgClientWithTransport creates new OpenAI API client for specified Organization ID with the provided http.Client.
-func NewOrgClientWithTransport(authToken, org string, transport *http.Client) *Client {
-	return &Client{
-		BaseURL:    apiURLv1,
-		HTTPClient: transport,
-		authToken:  authToken,
-		idOrg:      org,
-	}
-}
-
-// WithTransport returns the OpenAI API client configured to use the provided http.Client.
-func (c *Client) WithTransport(transport *http.Client) *Client {
-	c.HTTPClient = transport
-	return c
+	config := DefaultConfig(authToken)
+	config.OrgID = org
+	return &Client{config}
 }
 
 func (c *Client) sendRequest(req *http.Request, v interface{}) error {
 	req.Header.Set("Accept", "application/json; charset=utf-8")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.authToken))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.AuthToken))
 
 	// Check whether Content-Type is already set, Upload Files API requires
 	// Content-Type == multipart/form-data
@@ -77,11 +42,11 @@ func (c *Client) sendRequest(req *http.Request, v interface{}) error {
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	}
 
-	if len(c.idOrg) > 0 {
-		req.Header.Set("OpenAI-Organization", c.idOrg)
+	if len(c.config.OrgID) > 0 {
+		req.Header.Set("OpenAI-Organization", c.config.OrgID)
 	}
 
-	res, err := c.HTTPClient.Do(req)
+	res, err := c.config.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -112,5 +77,5 @@ func (c *Client) sendRequest(req *http.Request, v interface{}) error {
 }
 
 func (c *Client) fullURL(suffix string) string {
-	return fmt.Sprintf("%s%s", c.BaseURL, suffix)
+	return fmt.Sprintf("%s%s", c.config.BaseURL, suffix)
 }

--- a/api.go
+++ b/api.go
@@ -33,7 +33,7 @@ func NewOrgClient(authToken, org string) *Client {
 
 func (c *Client) sendRequest(req *http.Request, v interface{}) error {
 	req.Header.Set("Accept", "application/json; charset=utf-8")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.AuthToken))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
 
 	// Check whether Content-Type is already set, Upload Files API requires
 	// Content-Type == multipart/form-data

--- a/api.go
+++ b/api.go
@@ -30,6 +30,16 @@ func NewClient(authToken string) *Client {
 	}
 }
 
+// NewClientWithTransport creates new OpenAI API client with the provided http.Client.
+func NewClientWithTransport(authToken string, transport *http.Client) *Client {
+	return &Client{
+		BaseURL:    apiURLv1,
+		HTTPClient: transport,
+		authToken:  authToken,
+		idOrg:      "",
+	}
+}
+
 // NewOrgClient creates new OpenAI API client for specified Organization ID.
 func NewOrgClient(authToken, org string) *Client {
 	return &Client{
@@ -38,6 +48,22 @@ func NewOrgClient(authToken, org string) *Client {
 		authToken:  authToken,
 		idOrg:      org,
 	}
+}
+
+// NewOrgClientWithTransport creates new OpenAI API client for specified Organization ID with the provided http.Client.
+func NewOrgClientWithTransport(authToken, org string, transport *http.Client) *Client {
+	return &Client{
+		BaseURL:    apiURLv1,
+		HTTPClient: transport,
+		authToken:  authToken,
+		idOrg:      org,
+	}
+}
+
+// WithTransport returns the OpenAI API client configured to use the provided http.Client.
+func (c *Client) WithTransport(transport *http.Client) *Client {
+	c.HTTPClient = transport
+	return c
 }
 
 func (c *Client) sendRequest(req *http.Request, v interface{}) error {

--- a/api_test.go
+++ b/api_test.go
@@ -110,8 +110,10 @@ func TestAPIError(t *testing.T) {
 
 func TestRequestError(t *testing.T) {
 	var err error
-	c := NewClient("dummy")
-	c.BaseURL = "https://httpbin.org/status/418?"
+
+	config := DefaultConfig("dummy")
+	config.BaseURL = "https://httpbin.org/status/418?"
+	c := NewClientWithConfig(config)
 	ctx := context.Background()
 	_, err = c.ListEngines(ctx)
 	if err == nil {

--- a/completion_test.go
+++ b/completion_test.go
@@ -25,9 +25,10 @@ func TestCompletions(t *testing.T) {
 	ts.Start()
 	defer ts.Close()
 
-	client := NewClient(test.GetTestToken())
+	config := DefaultConfig(test.GetTestToken())
+	config.BaseURL = ts.URL + "/v1"
+	client := NewClientWithConfig(config)
 	ctx := context.Background()
-	client.BaseURL = ts.URL + "/v1"
 
 	req := CompletionRequest{
 		MaxTokens: 5,

--- a/config.go
+++ b/config.go
@@ -4,7 +4,10 @@ import (
 	"net/http"
 )
 
-const apiURLv1 = "https://api.openai.com/v1"
+const (
+	apiURLv1                       = "https://api.openai.com/v1"
+	defaultEmptyMessagesLimit uint = 300
+)
 
 // ClientConfig is a configuration of a client.
 type ClientConfig struct {
@@ -25,6 +28,6 @@ func DefaultConfig(authToken string) ClientConfig {
 		OrgID:      "",
 		authToken:  authToken,
 
-		EmptyMessagesLimit: 300,
+		EmptyMessagesLimit: defaultEmptyMessagesLimit,
 	}
 }

--- a/config.go
+++ b/config.go
@@ -1,0 +1,24 @@
+package gogpt
+
+import (
+	"net/http"
+)
+
+const apiURLv1 = "https://api.openai.com/v1"
+
+type ClientConfig struct {
+	HTTPClient *http.Client
+
+	BaseURL   string
+	OrgID     string
+	AuthToken string
+}
+
+func DefaultConfig(authToken string) ClientConfig {
+	return ClientConfig{
+		HTTPClient: &http.Client{},
+		BaseURL:    apiURLv1,
+		OrgID:      "",
+		AuthToken:  authToken,
+	}
+}

--- a/config.go
+++ b/config.go
@@ -12,6 +12,8 @@ type ClientConfig struct {
 	BaseURL   string
 	OrgID     string
 	AuthToken string
+
+	EmptyMessagesLimit uint
 }
 
 func DefaultConfig(authToken string) ClientConfig {
@@ -20,5 +22,7 @@ func DefaultConfig(authToken string) ClientConfig {
 		BaseURL:    apiURLv1,
 		OrgID:      "",
 		AuthToken:  authToken,
+
+		EmptyMessagesLimit: 300,
 	}
 }

--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ import (
 
 const apiURLv1 = "https://api.openai.com/v1"
 
+// ClientConfig is a configuration of a client.
 type ClientConfig struct {
 	authToken string
 

--- a/config.go
+++ b/config.go
@@ -7,11 +7,12 @@ import (
 const apiURLv1 = "https://api.openai.com/v1"
 
 type ClientConfig struct {
+	authToken string
+
 	HTTPClient *http.Client
 
-	BaseURL   string
-	OrgID     string
-	AuthToken string
+	BaseURL string
+	OrgID   string
 
 	EmptyMessagesLimit uint
 }
@@ -21,7 +22,7 @@ func DefaultConfig(authToken string) ClientConfig {
 		HTTPClient: &http.Client{},
 		BaseURL:    apiURLv1,
 		OrgID:      "",
-		AuthToken:  authToken,
+		authToken:  authToken,
 
 		EmptyMessagesLimit: 300,
 	}

--- a/edits_test.go
+++ b/edits_test.go
@@ -23,9 +23,10 @@ func TestEdits(t *testing.T) {
 	ts.Start()
 	defer ts.Close()
 
-	client := NewClient(test.GetTestToken())
+	config := DefaultConfig(test.GetTestToken())
+	config.BaseURL = ts.URL + "/v1"
+	client := NewClientWithConfig(config)
 	ctx := context.Background()
-	client.BaseURL = ts.URL + "/v1"
 
 	// create an edit request
 	model := "ada"

--- a/files_test.go
+++ b/files_test.go
@@ -22,9 +22,10 @@ func TestFileUpload(t *testing.T) {
 	ts.Start()
 	defer ts.Close()
 
-	client := NewClient(test.GetTestToken())
+	config := DefaultConfig(test.GetTestToken())
+	config.BaseURL = ts.URL + "/v1"
+	client := NewClientWithConfig(config)
 	ctx := context.Background()
-	client.BaseURL = ts.URL + "/v1"
 
 	req := FileRequest{
 		FileName: "test.go",

--- a/image_test.go
+++ b/image_test.go
@@ -23,9 +23,10 @@ func TestImages(t *testing.T) {
 	ts.Start()
 	defer ts.Close()
 
-	client := NewClient(test.GetTestToken())
+	config := DefaultConfig(test.GetTestToken())
+	config.BaseURL = ts.URL + "/v1"
+	client := NewClientWithConfig(config)
 	ctx := context.Background()
-	client.BaseURL = ts.URL + "/v1"
 
 	req := ImageRequest{}
 	req.Prompt = "Lorem ipsum"
@@ -94,9 +95,10 @@ func TestImageEdit(t *testing.T) {
 	ts.Start()
 	defer ts.Close()
 
-	client := NewClient(test.GetTestToken())
+	config := DefaultConfig(test.GetTestToken())
+	config.BaseURL = ts.URL + "/v1"
+	client := NewClientWithConfig(config)
 	ctx := context.Background()
-	client.BaseURL = ts.URL + "/v1"
 
 	origin, err := os.Create("image.png")
 	if err != nil {

--- a/moderation_test.go
+++ b/moderation_test.go
@@ -25,9 +25,10 @@ func TestModerations(t *testing.T) {
 	ts.Start()
 	defer ts.Close()
 
-	client := NewClient(test.GetTestToken())
+	config := DefaultConfig(test.GetTestToken())
+	config.BaseURL = ts.URL + "/v1"
+	client := NewClientWithConfig(config)
 	ctx := context.Background()
-	client.BaseURL = ts.URL + "/v1"
 
 	// create an edit request
 	model := "text-moderation-stable"

--- a/stream.go
+++ b/stream.go
@@ -74,13 +74,13 @@ func (c *Client) CreateCompletionStream(
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Connection", "keep-alive")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.authToken))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.AuthToken))
 	if err != nil {
 		return
 	}
 
 	req = req.WithContext(ctx)
-	resp, err := c.HTTPClient.Do(req) //nolint:bodyclose // body is closed in stream.Close()
+	resp, err := c.config.HTTPClient.Do(req) //nolint:bodyclose // body is closed in stream.Close()
 	if err != nil {
 		return
 	}

--- a/stream.go
+++ b/stream.go
@@ -75,7 +75,7 @@ func (c *Client) CreateCompletionStream(
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Connection", "keep-alive")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.AuthToken))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.config.authToken))
 	if err != nil {
 		return
 	}

--- a/stream_test.go
+++ b/stream_test.go
@@ -37,20 +37,21 @@ func TestCreateCompletionStream(t *testing.T) {
 	defer server.Close()
 
 	// Client portion of the test
-	client := NewClient(test.GetTestToken())
+	config := DefaultConfig(test.GetTestToken())
+	config.BaseURL = server.URL + "/v1"
+	config.HTTPClient.Transport = &tokenRoundTripper{
+		test.GetTestToken(),
+		http.DefaultTransport,
+	}
+
+	client := NewClientWithConfig(config)
 	ctx := context.Background()
-	client.BaseURL = server.URL + "/v1"
 
 	request := CompletionRequest{
 		Prompt:    "Ex falso quodlibet",
 		Model:     "text-davinci-002",
 		MaxTokens: 10,
 		Stream:    true,
-	}
-
-	client.HTTPClient.Transport = &tokenRoundTripper{
-		test.GetTestToken(),
-		http.DefaultTransport,
 	}
 
 	stream, err := client.CreateCompletionStream(ctx, request)


### PR DESCRIPTION
This PR aims to make the client completely configurable, following up #75 and #4. It also fixes #70.

The idea is to pass-by-value config struct, which would be encapsulated inside the client.

Here we preserve the standard way of creating clients as `client := gogpt.NewClient("auth token")` and add a new way of configuring clients:

```go
config := DefaultConfig("auth token")
config.BaseURL = server.URL + "/v1"
config.OrgID = "my org id"
config.HTTPClient.Transport = &tokenRoundTripper{
	test.GetTestToken(),
	http.DefaultTransport,
}
config.EmptyMessagesLimit = 10000

client := NewClientWithConfig(config)
ctx := context.Background()
```